### PR TITLE
Fix database helper parameter handling

### DIFF
--- a/Bll/FailureRecordBll.cs
+++ b/Bll/FailureRecordBll.cs
@@ -2,7 +2,6 @@
 using Database;
 using Database.Model;
 using MySql.Data.MySqlClient;
-using Mysqlx.Crud;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -237,3 +236,4 @@ namespace Bll
         }
     }
 }
+

--- a/Database/MySqlHelper.cs
+++ b/Database/MySqlHelper.cs
@@ -59,7 +59,10 @@ namespace Database
                 OpenConnection();
                 using (MySqlCommand command = new MySqlCommand(query, connection))
                 {
-                    command.Parameters.AddRange(parameters);
+                    if (parameters != null && parameters.Length > 0)
+                    {
+                        command.Parameters.AddRange(parameters);
+                    }
                     using (MySqlDataAdapter adapter = new MySqlDataAdapter(command))
                     {
                         adapter.Fill(dataTable);
@@ -86,7 +89,10 @@ namespace Database
                 OpenConnection();
                 using (MySqlCommand command = new MySqlCommand(query, connection))
                 {
-                    command.Parameters.AddRange(paras);
+                    if (paras != null && paras.Length > 0)
+                    {
+                        command.Parameters.AddRange(paras);
+                    }
                     rowsAffected = command.ExecuteNonQuery();
                 }
             }
@@ -109,7 +115,10 @@ namespace Database
                 OpenConnection();
                 using (MySqlCommand command = new MySqlCommand(query, connection))
                 {
-                    command.Parameters.AddRange(paras);
+                    if (paras != null && paras.Length > 0)
+                    {
+                        command.Parameters.AddRange(paras);
+                    }
                     result = command.ExecuteScalar();
                 }
             }

--- a/Database/SqlServerHelper.cs
+++ b/Database/SqlServerHelper.cs
@@ -98,7 +98,10 @@ namespace Database
             {
                 cmd.CommandType = CommandType.StoredProcedure;
                 cmd.CommandText = storageProcName;
-                cmd.Parameters.AddRange(paras);
+                if (paras != null && paras.Length > 0)
+                {
+                    cmd.Parameters.AddRange(paras);
+                }
                 using (SqlDataAdapter adapter = new SqlDataAdapter(cmd))
                 {
                     adapter.Fill(dt);
@@ -109,3 +112,4 @@ namespace Database
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- guard `AddRange` with null checks in `MySqlHelper`
- guard stored proc parameters with null check in `SqlServerHelper`
- remove unused import from `FailureRecordBll`

## Testing
- `dotnet build PDMS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684110ab6bd48323a9e01c3f6754fa96